### PR TITLE
multi-hop via and update-last seen

### DIFF
--- a/mitosis/src/configuration.ts
+++ b/mitosis/src/configuration.ts
@@ -17,6 +17,7 @@ export class Configuration {
   public static readonly CONNECTION_METER_OPEN_GRACE_PERIOD_TIME: number = 10;
   public static readonly CONNECTION_METER_PROTECTION_TIME: number = 10;
   public static readonly CONNECTION_METER_PUNISHMENT_TIME: number = 20;
+  public static readonly LAST_SEEN_TIMEOUT: number = 30;
 }
 
 export class SignalConfiguration extends Configuration {

--- a/mitosis/src/connection/connection-table.ts
+++ b/mitosis/src/connection/connection-table.ts
@@ -13,24 +13,8 @@ export class ConnectionTable extends Table<IConnection, ConnectionTable> {
   }
 
   public filterDirect(): ConnectionTable {
-    return new ConnectionTable(
-      this._values.filter(
-        connection => connection.getAddress().getProtocol() !== Protocol.VIA
-      )
-    );
-  }
-
-  public filterVia(viaPeerId?: string): ConnectionTable {
-    return new ConnectionTable(
-      this._values.filter(
-        connection => {
-          if (viaPeerId && viaPeerId !== connection.getAddress().getLocation()) {
-            return false;
-          } else {
-            return connection.getAddress().getProtocol() === Protocol.VIA;
-          }
-        }
-      )
+    return this.exclude(
+      table => table.filterByProtocol(Protocol.VIA, Protocol.VIA_MULTI)
     );
   }
 
@@ -38,6 +22,14 @@ export class ConnectionTable extends Table<IConnection, ConnectionTable> {
     return new ConnectionTable(
       this._values.filter(
         connection => connection.getAddress().isProtocol(...protocols)
+      )
+    );
+  }
+
+  public filterByLocation(location: string) {
+    return new ConnectionTable(
+      this._values.filter(
+        connection => connection.getAddress().getLocation() === location
       )
     );
   }

--- a/mitosis/src/connection/interface.ts
+++ b/mitosis/src/connection/interface.ts
@@ -16,7 +16,8 @@ export enum Protocol {
   WEBSOCKET = 'wss',
   WEBRTC_DATA = 'webrtc-data',
   WEBRTC_STREAM = 'webrtc-stream',
-  VIA = 'via'
+  VIA = 'via',
+  VIA_MULTI = 'via-multi'
 }
 
 export interface IConnectionChurnEvent {

--- a/mitosis/src/connection/interface.ts
+++ b/mitosis/src/connection/interface.ts
@@ -36,6 +36,7 @@ export interface IViaConnectionOptions extends IConnectionOptions {
 
 export interface IViaConnectionOptionsPayload {
   parent: IConnection;
+  quality: number;
 }
 
 export interface IWebRTCConnectionOptions extends IConnectionOptions {

--- a/mitosis/src/connection/protocol-map.ts
+++ b/mitosis/src/connection/protocol-map.ts
@@ -10,3 +10,4 @@ ProtocolConnectionMap.set(Protocol.WEBSOCKET_UNSECURE, WebSocketConnection);
 ProtocolConnectionMap.set(Protocol.WEBRTC_DATA, WebRTCDataConnection);
 ProtocolConnectionMap.set(Protocol.WEBRTC_STREAM, WebRTCStreamConnection);
 ProtocolConnectionMap.set(Protocol.VIA, ViaConnection);
+ProtocolConnectionMap.set(Protocol.VIA_MULTI, ViaConnection);

--- a/mitosis/src/connection/via.ts
+++ b/mitosis/src/connection/via.ts
@@ -13,7 +13,7 @@ export class ViaConnection extends AbstractConnection implements IConnection {
 
   constructor(address: Address, clock: IClock, options: IViaConnectionOptions) {
     super(address, clock, options);
-    this._meter = new ViaConnectionMeter(this, clock);
+    this._meter = new ViaConnectionMeter(this, clock, options.payload.quality);
   }
 
   private parentStateChanged(connectionState: ConnectionState): void {

--- a/mitosis/src/message/interface.ts
+++ b/mitosis/src/message/interface.ts
@@ -7,6 +7,7 @@ export enum MessageSubject {
   ROLE_UPDATE = 'role-update',
   CONNECTION_NEGOTIATION = 'connection-negotiation',
   APP_CONTENT = 'app-content',
+  UNKNOWN_PEER = 'unknown-peer',
   PING = 'ping',
   PONG = 'pong',
   ROUTER_ALIVE = 'router-alive'

--- a/mitosis/src/message/message-broker.ts
+++ b/mitosis/src/message/message-broker.ts
@@ -139,7 +139,9 @@ export class MessageBroker {
     const receiverPeer = this._peerManager.getPeerById(peerId);
     if (!receiverPeer) {
       Logger.getLogger(this._peerManager.getMyId()).debug(`no idea how to reach ${peerId}`, message);
-      this._peerManager.sendPeerUpdate(message.getInboundAddress());
+      this._peerManager.sendMessage(
+        new UnknownPeer(message.getReceiver(), message.getInboundAddress(), peerId)
+      );
       return;
     }
     const connection = receiverPeer.getConnectionTable()

--- a/mitosis/src/message/message-broker.ts
+++ b/mitosis/src/message/message-broker.ts
@@ -85,7 +85,7 @@ export class MessageBroker {
     const senderId = message.getSender().getId();
 
     this._peerManager
-      .ensureConnection(senderId, viaPeerId)
+      .ensureConnection(new Address(senderId, Protocol.VIA_MULTI, viaPeerId), {payload: {quality: 0.1}})
       .catch(
         reason =>
           Logger.getLogger(this._peerManager.getMyId()).warn(reason, message)

--- a/mitosis/src/message/message-broker.ts
+++ b/mitosis/src/message/message-broker.ts
@@ -161,7 +161,7 @@ export class MessageBroker {
       Logger.getLogger(this._peerManager.getMyId()).error(`all connections lost to ${peerId}`, message);
       return;
     }
-    if (connection.getAddress().getProtocol() === Protocol.VIA) {
+    if (connection.getAddress().isProtocol(Protocol.VIA, Protocol.VIA_MULTI)) {
       const directPeerId = connection.getAddress().getLocation();
       const directPeer = this._peerManager.getPeerById(directPeerId);
       directPeer.send(message);

--- a/mitosis/src/message/message-broker.ts
+++ b/mitosis/src/message/message-broker.ts
@@ -145,7 +145,7 @@ export class MessageBroker {
     const connection = receiverPeer.getConnectionTable()
       .filterByStates(ConnectionState.OPEN)
       .sortByQuality()
-      .shift();
+      .pop();
     if (!connection) {
       Logger.getLogger(this._peerManager.getMyId()).error(`all connections lost to ${peerId}`, message);
       return;

--- a/mitosis/src/message/message-broker.ts
+++ b/mitosis/src/message/message-broker.ts
@@ -98,6 +98,15 @@ export class MessageBroker {
       case MessageSubject.PEER_UPDATE:
         this._peerManager.updatePeers(message as PeerUpdate, viaPeerId);
         break;
+      case MessageSubject.UNKNOWN_PEER:
+        const existingPeer = this._peerManager.getPeerById(message.getBody());
+        if (existingPeer) {
+          existingPeer
+            .getConnectionTable()
+            .filterByLocation(message.getInboundAddress().getId())
+            .forEach(connection => connection.close());
+        }
+        break;
       case MessageSubject.CONNECTION_NEGOTIATION:
         this._peerManager.negotiateConnection(message as ConnectionNegotiation);
         break;

--- a/mitosis/src/message/message-broker.ts
+++ b/mitosis/src/message/message-broker.ts
@@ -11,7 +11,10 @@ import {IMessage, MessageSubject} from './interface';
 import {PeerUpdate} from './peer-update';
 import {RoleUpdate} from './role-update';
 import {FloodingHandler} from './flooding-handler';
-import {Configuration, Globals} from '../configuration';
+import {Globals} from '../configuration';
+import {Address} from './address';
+import {UnknownPeer} from './unknown-peer';
+import {RoleType} from '../role/interface';
 
 export class MessageBroker {
 

--- a/mitosis/src/message/message-broker.ts
+++ b/mitosis/src/message/message-broker.ts
@@ -118,6 +118,10 @@ export class MessageBroker {
         break;
       case MessageSubject.ROUTER_ALIVE:
         if (this._routerAliveFloodingHandler.isFirstMessage(message)) {
+          const routerPeer = this._peerManager.getPeerById(message.getSender().getId());
+          if (routerPeer) {
+            routerPeer.setRoles([RoleType.PEER, RoleType.ROUTER]);
+          }
           // TODO handle router alive message
           Logger.getLogger(this._peerManager.getMyId())
             .warn(

--- a/mitosis/src/message/unknown-peer.ts
+++ b/mitosis/src/message/unknown-peer.ts
@@ -1,0 +1,17 @@
+import {ConnectionState} from '../connection/interface';
+import {RemotePeerTable} from '../peer/remote-peer-table';
+import {Address} from './address';
+import {IPeerUpdateEntry, MessageSubject} from './interface';
+import {Message} from './message';
+
+export class UnknownPeer extends Message {
+  protected _body: string;
+
+  public constructor(sender: Address, receiver: Address, remotePeerId: string) {
+    super(sender, receiver, MessageSubject.UNKNOWN_PEER, remotePeerId);
+  }
+
+  public getBody(): string {
+    return this._body;
+  }
+}

--- a/mitosis/src/metering/connection-meter/connection-meter.ts
+++ b/mitosis/src/metering/connection-meter/connection-meter.ts
@@ -38,6 +38,10 @@ export abstract class ConnectionMeter {
     }
   }
 
+  protected updateLastSeen() {
+    this._lastSeenTick = this._clock.getTick();
+  }
+
   private setProtected(isProtected: boolean) {
     const wasProtected = this._protected;
     this._protected = isProtected;

--- a/mitosis/src/metering/connection-meter/connection-meter.ts
+++ b/mitosis/src/metering/connection-meter/connection-meter.ts
@@ -68,6 +68,10 @@ export abstract class ConnectionMeter {
     }
   }
 
+  public isLastSeenExpired() {
+    return (this._clock.getTick() - this._lastSeenTick) > Configuration.LAST_SEEN_TIMEOUT;
+  }
+
   public getLastSeen(): number {
     return this._lastSeenTick;
   }

--- a/mitosis/src/metering/connection-meter/interface.ts
+++ b/mitosis/src/metering/connection-meter/interface.ts
@@ -22,5 +22,7 @@ export interface IConnectionMeter extends IMeter {
 
   getLastSeen(): number;
 
+  isLastSeenExpired(): boolean;
+
   observe(): Subject<IConnectionMeterEvent>;
 }

--- a/mitosis/src/metering/connection-meter/via-connection-meter.ts
+++ b/mitosis/src/metering/connection-meter/via-connection-meter.ts
@@ -4,9 +4,16 @@ import {ConnectionMeter} from './connection-meter';
 import {IConnectionMeter} from './interface';
 
 export class ViaConnectionMeter extends ConnectionMeter implements IConnectionMeter {
+  private _quality: number;
+
+  constructor(connection: IConnection, clock: IClock, quality = 1) {
+    super(connection, clock);
+    this._quality = quality;
+  }
+
   public getQuality(): number {
     // TODO: Calculate quality from PUs and direct connection
-    return 1;
+    return this._quality;
   }
 
   public start(): void {

--- a/mitosis/src/metering/connection-meter/via-connection-meter.ts
+++ b/mitosis/src/metering/connection-meter/via-connection-meter.ts
@@ -11,6 +11,10 @@ export class ViaConnectionMeter extends ConnectionMeter implements IConnectionMe
     this._quality = quality;
   }
 
+  public updateLastSeen() {
+    super.updateLastSeen();
+  }
+
   public getQuality(): number {
     // TODO: Calculate quality from PUs and direct connection
     return this._quality;

--- a/mitosis/src/metering/remote-peer-meter.ts
+++ b/mitosis/src/metering/remote-peer-meter.ts
@@ -35,6 +35,14 @@ export class RemotePeerMeter implements IMeter {
       );
   }
 
+  public lastSeenIsExpired(): boolean {
+    const unExpiredConnection = this.getConnectionTable()
+      .find(
+        connection => (connection.getMeter() as IConnectionMeter).isLastSeenExpired() === false
+      );
+    return !unExpiredConnection;
+  }
+
   // returns value between 0 and 1 which is the average tq of all connections
   public getAverageConnectionQuality(): number {
     const quality = this.getConnectionTable()

--- a/mitosis/src/peer/peer-manager.ts
+++ b/mitosis/src/peer/peer-manager.ts
@@ -50,9 +50,13 @@ export class PeerManager {
         .forEach(
           peer => peer
             .getConnectionTable()
-            .filterVia(remotePeer.getId())
+            .filterByProtocol(Protocol.VIA, Protocol.VIA_MULTI)
+            .filterByLocation(remotePeer.getId())
             .forEach(
-              viaConnection => viaConnection.close()
+              viaConnection => {
+                Logger.getLogger(this._myId).warn('close via connection because parent connection was closed', viaConnection);
+                viaConnection.close();
+              }
             )
         );
     }
@@ -237,7 +241,8 @@ export class PeerManager {
       .forEach(
         peer => peer
           .getConnectionTable()
-          .filterVia(senderId)
+          .filterByProtocol(Protocol.VIA)
+          .filterByLocation(senderId)
           .filter(
             connection =>
               updatedPeerIds.indexOf(connection.getAddress().getId()) === -1

--- a/mitosis/src/peer/remote-peer.ts
+++ b/mitosis/src/peer/remote-peer.ts
@@ -154,7 +154,7 @@ export class RemotePeer {
       .filterByStates(ConnectionState.OPEN)
       .filterDirect()
       .sortByQuality()
-      .shift();
+      .pop();
     if (connection) {
       try {
         connection.send(message);

--- a/mitosis/src/role/task/close-duplicate-connections.ts
+++ b/mitosis/src/role/task/close-duplicate-connections.ts
@@ -18,7 +18,7 @@ export function closeDuplicateConnections(mitosis: Mitosis): void {
             protocol => {
               direct
                 .filter(
-                  connection => connection.getAddress().getProtocol() === protocol
+                  connection => connection.getAddress().isProtocol(protocol)
                 )
                 .sortBy(
                   connection => connection.getAddress().getLocation()

--- a/mitosis/src/role/task/degrade-to-newbie.ts
+++ b/mitosis/src/role/task/degrade-to-newbie.ts
@@ -7,7 +7,7 @@ export function degradeToNewbie(mitosis: Mitosis): void {
 
   if (!roleManager.hasRole(RoleType.NEWBIE) && mitosis.getPeerTable().length === 0) {
     Logger.getLogger(mitosis.getMyAddress().getId())
-      .debug('lost all connections');
+      .debug('lost all connections, becoming a newbie!');
     roleManager
       .getRoles()
       .forEach(

--- a/mitosis/src/role/task/satisfy-connection-goal.ts
+++ b/mitosis/src/role/task/satisfy-connection-goal.ts
@@ -48,8 +48,10 @@ export function satisfyConnectionGoal(mitosis: Mitosis): void {
       );
       const bestViaPeer = viaPeers
         .sortByQuality()
-        .shift();
+        .pop();
       const address = new Address(bestViaPeer.getId(), Protocol.WEBRTC_DATA);
+      Logger.getLogger(mitosis.getMyAddress().getId())
+        .debug(`connecting to best peer ${bestViaPeer.getId()} with quality ${bestViaPeer.getMeter().getQuality()}`);
       mitosis.getPeerManager().connectTo(address);
     } else {
       // No indirect peers to connect to: do nothing

--- a/mitosis/src/role/task/satisfy-connection-goal.ts
+++ b/mitosis/src/role/task/satisfy-connection-goal.ts
@@ -66,7 +66,7 @@ export function satisfyConnectionGoal(mitosis: Mitosis): void {
       )
       .sortByQuality();
     while (worstDirectPeers.length) {
-      const worstDirectPeer = worstDirectPeers.pop();
+      const worstDirectPeer = worstDirectPeers.shift();
       const success = mitosis
         .getPeerManager()
         .removePeer(worstDirectPeer);

--- a/mitosis/src/role/task/satisfy-connection-goal.ts
+++ b/mitosis/src/role/task/satisfy-connection-goal.ts
@@ -18,7 +18,7 @@ export function satisfyConnectionGoal(mitosis: Mitosis): void {
 
   const viaPeers = peerTable
     .filterConnections(
-      table => table.filterVia()
+      table => table.filterByProtocol(Protocol.VIA)
     )
     .exclude(
       table => {

--- a/mitosis/src/role/task/send-alternatives.ts
+++ b/mitosis/src/role/task/send-alternatives.ts
@@ -3,7 +3,6 @@ import {MessageSubject} from '../../message/interface';
 import {Message} from '../../message/message';
 import {PeerUpdate} from '../../message/peer-update';
 import {Mitosis} from '../../mitosis';
-import {SortOrder} from '../../util/table';
 
 export function sendAlternatives(mitosis: Mitosis, message: Message) {
   const peerManager = mitosis.getPeerManager();
@@ -40,7 +39,6 @@ export function sendAlternatives(mitosis: Mitosis, message: Message) {
 
   const alternativePeers = directPeers
     .sortByQuality(
-      SortOrder.DESC,
       meter => meter.getLastSeen(),
     );
 

--- a/mitosis/src/role/task/send-introduction.ts
+++ b/mitosis/src/role/task/send-introduction.ts
@@ -1,12 +1,14 @@
 import {Introduction} from '../../message/introduction';
 import {Mitosis} from '../../mitosis';
 import {RoleType} from '../interface';
+import {Logger} from '../../logger/logger';
 
 export function sendIntroduction(mitosis: Mitosis): void {
   const introduction = new Introduction(
     mitosis.getMyAddress(),
     mitosis.getSignalAddress()
   );
+  Logger.getLogger(mitosis.getMyAddress().getId()).debug('connecting to signal');
   mitosis.getPeerManager()
     .connectTo(mitosis.getSignalAddress())
     .then(

--- a/mitosis/src/util/table.ts
+++ b/mitosis/src/util/table.ts
@@ -20,6 +20,10 @@ export class Table<V, T extends Table<V, T>> implements Iterable<V> {
     );
   }
 
+  public find(callbackfn: (value: V) => boolean): V {
+    return this._values.find(callbackfn);
+  }
+
   public exclude(callbackfn: (table: T) => T): T {
     // const excluded = callbackfn(this as unknown as T)._values;
     const excluded = callbackfn(this.fromArray(this._values))._values;

--- a/simulation/src/instruction/finish-scenario.ts
+++ b/simulation/src/instruction/finish-scenario.ts
@@ -1,0 +1,13 @@
+import {Logger} from 'mitosis';
+import {Simulation} from '../simulation';
+import {AbstractInstruction} from './instruction';
+import {IInstruction} from './interface';
+
+export class FinishScenario extends AbstractInstruction implements IInstruction {
+
+  public execute(simulation: Simulation): void {
+    Logger.getLogger('simulation').info('scenario done');
+    simulation.getClock().setSpeed(1000);
+    simulation.getClock().pause();
+  }
+}

--- a/simulation/src/instruction/interface.ts
+++ b/simulation/src/instruction/interface.ts
@@ -1,6 +1,7 @@
 import {RoleType} from 'mitosis';
 import {Simulation} from '../simulation';
 import {AddPeer} from './add-peer';
+import {FinishScenario} from './finish-scenario';
 import {PauseClock} from './pause-clock';
 import {RemoveConnection} from './remove-connection';
 import {RemovePeer} from './remove-peer';
@@ -15,7 +16,8 @@ export enum InstructionType {
   START_CLOCK = 'start-clock',
   PAUSE_CLOCK = 'pause-clock',
   STOP_CLOCK = 'stop-clock',
-  SET_CLOCK_SPEED = 'set-clock-speed'
+  SET_CLOCK_SPEED = 'set-clock-speed',
+  FINISH_SCENARIO = 'finish-scenario'
 }
 
 export type IInstructionConstructor = new(...args: Array<any>) => IInstruction;
@@ -27,7 +29,8 @@ export const InstructionTypeMap: Map<InstructionType, IInstructionConstructor> =
   [InstructionType.START_CLOCK, StartClock],
   [InstructionType.PAUSE_CLOCK, PauseClock],
   [InstructionType.STOP_CLOCK, StopClock],
-  [InstructionType.SET_CLOCK_SPEED, SetClockSpeed]
+  [InstructionType.SET_CLOCK_SPEED, SetClockSpeed],
+  [InstructionType.FINISH_SCENARIO, FinishScenario]
 ]);
 
 export interface IConfiguration {

--- a/visualization/src/app/main/components/sidebar/peer-table/peer-table.html
+++ b/visualization/src/app/main/components/sidebar/peer-table/peer-table.html
@@ -18,7 +18,7 @@
         <div class="left">
           <app-button type="icon"
                       text="fa fa-trash"
-                      [disabled]="connection.getAddress().getProtocol()==='via'"
+                      [disabled]="isDisabled(connection)"
                       (click)="connection.close()">
           </app-button>
           {{connection.getAddress().getProtocol()}}

--- a/visualization/src/app/main/components/sidebar/peer-table/peer-table.html
+++ b/visualization/src/app/main/components/sidebar/peer-table/peer-table.html
@@ -4,7 +4,8 @@
                    id="rtbl-{{selectedNode.getId()+'-'+remotePeer.getId()}}"
                    [isCollapsed]="true"
                    [title]="remotePeer.getId()"
-                   [text]="getPeerAnnotation(remotePeer)">
+                   [text]="getPeerAnnotation(remotePeer)"
+                   [class.expired]="remotePeer.getMeter().lastSeenIsExpired()">
     <ul class="connections">
       <div class="meter">
         <pre>
@@ -12,6 +13,7 @@
           ⌀PunQ: {{remotePeer.getMeter().getAverageConnectionPunishment().toFixed(2)}},
           ProQ: {{remotePeer.getMeter().getConnectionProtection()}}
           LastSeen: {{remotePeer.getMeter().getLastSeen()}}
+          isExpired: {{remotePeer.getMeter().lastSeenIsExpired() | json}}
         </pre>
       </div>
       <li *ngFor="let connection of remotePeer.getConnectionTable()">

--- a/visualization/src/app/main/components/sidebar/peer-table/peer-table.ts
+++ b/visualization/src/app/main/components/sidebar/peer-table/peer-table.ts
@@ -1,5 +1,5 @@
 import {Component, Input, OnInit} from '@angular/core';
-import {ConnectionState, IConnection, Protocol, RemotePeer, RoleType} from 'mitosis';
+import {ConnectionState, IConnection, IConnectionMeter, Protocol, RemotePeer, RoleType} from 'mitosis';
 import {Node, Simulation} from 'mitosis-simulation';
 
 @Component({

--- a/visualization/src/app/main/components/sidebar/peer-table/peer-table.ts
+++ b/visualization/src/app/main/components/sidebar/peer-table/peer-table.ts
@@ -1,5 +1,5 @@
 import {Component, Input, OnInit} from '@angular/core';
-import {ConnectionState, Protocol, RemotePeer, RoleType} from 'mitosis';
+import {ConnectionState, IConnection, Protocol, RemotePeer, RoleType} from 'mitosis';
 import {Node, Simulation} from 'mitosis-simulation';
 
 @Component({
@@ -15,6 +15,10 @@ export class PeerTableComponent implements OnInit {
   public simulation: Simulation;
 
   constructor() {
+  }
+
+  public isDisabled(connection: IConnection) {
+    return connection.getAddress().isProtocol(Protocol.VIA, Protocol.VIA_MULTI);
   }
 
   public getPeerAnnotation(peer: RemotePeer) {
@@ -34,7 +38,7 @@ export class PeerTableComponent implements OnInit {
     const directText = `${directConnections.length - nonOpenConnections.length}/${directConnections.length}`;
 
     const viaText = peer.getConnectionTable()
-      .filterByProtocol(Protocol.VIA_SINGLE, Protocol.VIA_MULTI)
+      .filterByProtocol(Protocol.VIA, Protocol.VIA_MULTI)
       .length
       .toString();
 

--- a/visualization/src/app/main/components/sidebar/sidebar.scss
+++ b/visualization/src/app/main/components/sidebar/sidebar.scss
@@ -43,6 +43,20 @@
       margin-right: 0;
     }
 
+    /deep/ app-collapsible {
+      &.expired {
+        .collapsible {
+          opacity: 0.5;
+
+          .collapsible-head {
+            .title {
+              text-decoration: line-through;
+            }
+          }
+        }
+      }
+    }
+
     .scenario-setup {
       padding-bottom: 0;
 

--- a/visualization/src/app/main/components/simulation/simulation.ts
+++ b/visualization/src/app/main/components/simulation/simulation.ts
@@ -93,9 +93,7 @@ export class SimulationComponent implements OnInit {
             console.log('CONNECTION-TABLE', remotePeer.getConnectionTable())
             remotePeer
               .getConnectionTable()
-              .exclude(
-                table => table.filterByProtocol(Protocol.VIA_SINGLE, Protocol.VIA_MULTI)
-              )
+              .filterDirect()
               .forEach(
                 connection => {
                   console.log('ADD', connection.getAddress().getProtocol(), connection.getAddress().toString());

--- a/visualization/src/app/main/components/simulation/simulation.ts
+++ b/visualization/src/app/main/components/simulation/simulation.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {Logger, Protocol} from 'mitosis';
+import {Logger} from 'mitosis';
 import {Edge, MockConnection, Simulation} from 'mitosis-simulation';
 import {Subscription} from 'rxjs';
 import {LogEventLogger} from '../../services/log-event-logger';
@@ -14,16 +14,14 @@ import {SidebarComponent} from '../sidebar/sidebar';
   styleUrls: ['./simulation.scss'],
 })
 export class SimulationComponent implements OnInit {
-  private simulation: Simulation;
-
   public model: D3Model;
   public selectedNode: Node;
-
   @ViewChild('graph')
   public graph: D3DirectedGraphComponent;
-
   @ViewChild('sidebar')
   public sidebar: SidebarComponent;
+  private scenario: any;
+  private simulation: Simulation;
 
   constructor(private logEventLogger: LogEventLogger,
               private messageEventLogger: MessageEventLogger) {
@@ -53,6 +51,7 @@ export class SimulationComponent implements OnInit {
   }
 
   public updateScenario(scenario: any) {
+    this.scenario = scenario;
     this.simulation.reset();
     this.simulation.start(scenario);
     let subscriptions: Subscription = new Subscription();
@@ -90,15 +89,12 @@ export class SimulationComponent implements OnInit {
           .getPeerManager()
           .getPeerTable()
           .forEach(remotePeer => {
-            console.log('CONNECTION-TABLE', remotePeer.getConnectionTable())
             remotePeer
               .getConnectionTable()
               .filterDirect()
               .forEach(
-                connection => {
-                  console.log('ADD', connection.getAddress().getProtocol(), connection.getAddress().toString());
-                  model.addEdge(new Edge(node.getId(), connection as MockConnection));
-                }
+                connection =>
+                  model.addEdge(new Edge(node.getId(), connection as MockConnection))
               );
           });
       });
@@ -146,9 +142,33 @@ export class SimulationComponent implements OnInit {
       }
     });
 
-    window.addEventListener('keydown', function (e) {
+    let metaPressed = false;
+    let shiftPressed = false;
+
+    window.addEventListener('keydown', (e) => {
       if (e.code === 'Space' && e.target === document.body) {
         e.preventDefault();
+      }
+      if (e.key === 'Meta') {
+        metaPressed = true;
+      }
+      if (e.key === 'Shift') {
+        shiftPressed = true;
+      }
+      if (e.key === 'r' && metaPressed && !shiftPressed) {
+        if (this.scenario) {
+          e.preventDefault();
+          this.updateScenario(this.scenario);
+        }
+      }
+    });
+
+    window.addEventListener('keyup', (e) => {
+      if (e.key === 'Meta') {
+        metaPressed = false;
+      }
+      if (e.key === 'Shift') {
+        shiftPressed = false;
       }
     });
   }

--- a/visualization/src/app/main/src/event-logger.ts
+++ b/visualization/src/app/main/src/event-logger.ts
@@ -19,7 +19,7 @@ export class LogEvent<TLog> {
 }
 
 export class NodeEventLogger<TLog> {
-  public static maxSize = 1000;
+  public static maxSize = 100;
 
   private _logs: Array<LogEvent<TLog>>;
 

--- a/visualization/src/app/shared/components/ui/inputs/selector/selector.ts
+++ b/visualization/src/app/shared/components/ui/inputs/selector/selector.ts
@@ -39,7 +39,7 @@ export class SelectorComponent implements ControlValueAccessor {
   @Output()
   public valueChanged = new EventEmitter();
 
-  private updateValue(value: number) {
+  public updateValue(value: number) {
     if (this._onChange) {
       this.value = value;
       this._onChange(this.value);

--- a/visualization/src/scenarios/_index.json
+++ b/visualization/src/scenarios/_index.json
@@ -3,5 +3,6 @@
   "crowd.json",
   "group.json",
   "friends.json",
+  "fünf-freunde.json",
   "triangle.json"
 ]

--- a/visualization/src/scenarios/crowd.json
+++ b/visualization/src/scenarios/crowd.json
@@ -208,6 +208,10 @@
         "address": "mitosis/v1/zoe/webrtc",
         "signal": "mitosis/v1/signal/wss"
       }
+    },
+    {
+      "tick": 110,
+      "type": "finish-scenario"
     }
   ]
 }

--- a/visualization/src/scenarios/friends.json
+++ b/visualization/src/scenarios/friends.json
@@ -4,7 +4,7 @@
       "tick": 0,
       "type": "set-clock-speed",
       "configuration": {
-        "speed": 100
+        "speed": 50
       }
     },
     {
@@ -42,15 +42,8 @@
       }
     },
     {
-      "tick": 20,
-      "type": "set-clock-speed",
-      "configuration": {
-        "speed": 1000
-      }
-    },
-    {
       "tick": 30,
-      "type": "pause-clock"
+      "type": "finish-scenario"
     }
   ]
 }

--- a/visualization/src/scenarios/fünf-freunde.json
+++ b/visualization/src/scenarios/fünf-freunde.json
@@ -58,8 +58,8 @@
       }
     },
     {
-      "tick": 50,
-      "type": "pause-clock"
+      "tick": 30,
+      "type": "finish-scenario"
     }
   ]
 }

--- a/visualization/src/scenarios/fünf-freunde.json
+++ b/visualization/src/scenarios/fünf-freunde.json
@@ -1,0 +1,61 @@
+{
+  "instructions": [
+    {
+      "tick": 0,
+      "type": "set-clock-speed",
+      "configuration": {
+        "speed": 250
+      }
+    },
+    {
+      "tick": 0,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/signal/wss",
+        "roles": [
+          "signal"
+        ]
+      }
+    },
+    {
+      "tick": 1,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/alice/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 2,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/bob/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 2,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/chloe/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 3,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/dylan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 3,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/eve/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    }
+  ]
+}

--- a/visualization/src/scenarios/fünf-freunde.json
+++ b/visualization/src/scenarios/fünf-freunde.json
@@ -4,7 +4,7 @@
       "tick": 0,
       "type": "set-clock-speed",
       "configuration": {
-        "speed": 250
+        "speed": 50
       }
     },
     {
@@ -56,6 +56,10 @@
         "address": "mitosis/v1/eve/webrtc",
         "signal": "mitosis/v1/signal/wss"
       }
+    },
+    {
+      "tick": 50,
+      "type": "pause-clock"
     }
   ]
 }

--- a/visualization/src/scenarios/group.json
+++ b/visualization/src/scenarios/group.json
@@ -4,7 +4,7 @@
       "tick": 0,
       "type": "set-clock-speed",
       "configuration": {
-        "speed": 250
+        "speed": 50
       }
     },
     {
@@ -96,6 +96,10 @@
         "address": "mitosis/v1/jack/webrtc",
         "signal": "mitosis/v1/signal/wss"
       }
+    },
+    {
+      "tick": 87,
+      "type": "finish-scenario"
     }
   ]
 }

--- a/visualization/src/scenarios/population.json
+++ b/visualization/src/scenarios/population.json
@@ -1,1620 +1,1624 @@
 {
-    "instructions": [
-        {
-            "tick": 0,
-            "type": "set-clock-speed",
-            "configuration": {
-                "speed": 250
-            }
-        },
-        {
-            "tick": 0,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/signal/wss",
-                "roles": [
-                    "signal"
-                ]
-            }
-        },
-        {
-            "tick": 1,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/aaron/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 2,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/abigail/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 3,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/adam/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 4,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/addison/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 5,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/adrian/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 6,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/aidan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 7,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/aiden/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 8,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/alejandro/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 9,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/alex/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 10,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/alexa/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 11,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/alexander/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 12,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/alexandra/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 13,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/alexis/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 14,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/allison/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 15,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/alyssa/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 16,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/amanda/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 17,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/amber/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 18,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/andrea/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 19,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/andrew/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 20,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/angel/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 21,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/angelina/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 22,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/anna/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 23,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/anthony/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 24,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/antonio/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 25,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/ariana/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 26,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/arianna/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 27,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/ashley/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 28,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/audrey/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 29,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/austin/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 30,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/autumn/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 31,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/ava/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 32,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/avery/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 33,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/bailey/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 34,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/benjamin/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 35,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/blake/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 36,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/brandon/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 37,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/brayden/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 38,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/brian/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 39,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/brianna/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 40,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/brooke/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 41,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/brooklyn/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 42,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/bryan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 43,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/caleb/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 44,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/cameron/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 45,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/carlos/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 46,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/caroline/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 47,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/carson/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 48,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/carter/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 49,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/charles/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 50,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/chase/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 51,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/chloe/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 52,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/christian/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 53,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/christopher/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 54,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/claire/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 55,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/cody/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 56,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/cole/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 57,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/connor/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 58,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/daniel/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 59,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/danielle/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 60,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/david/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 61,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/destiny/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 62,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/devin/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 63,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/diego/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 64,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/dominic/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 65,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/dylan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 66,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/elijah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 67,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/elizabeth/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 68,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/ella/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 69,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/emily/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 70,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/emma/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 71,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/eric/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 72,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/erin/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 73,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/ethan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 74,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/evan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 75,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/evelyn/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 76,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/faith/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 77,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/gabriel/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 78,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/gabriella/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 79,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/gabrielle/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 80,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/gavin/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 81,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/grace/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 82,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/hailey/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 83,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/haley/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 84,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/hannah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 85,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/hayden/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 86,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/hunter/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 87,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/ian/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 88,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/isaac/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 89,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/isabel/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 90,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/isabella/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 91,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/isaiah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 92,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jack/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 93,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jackson/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 94,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jacob/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 95,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jacqueline/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 96,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jada/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 97,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jaden/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 98,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/james/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 99,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jasmine/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 100,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jason/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 101,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jayden/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 102,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jenna/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 103,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jennifer/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 104,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jeremiah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 105,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jesse/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 106,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jessica/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 107,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jesus/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 108,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jocelyn/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 109,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/john/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 110,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jonathan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 111,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jordan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 112,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jordan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 113,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/jose/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 114,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/joseph/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 115,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/joshua/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 116,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/juan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 117,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/julia/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 118,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/julian/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 119,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/justin/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 120,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/kaitlyn/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 121,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/katelyn/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 122,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/katherine/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 123,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/kayla/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 124,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/kaylee/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 125,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/kevin/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 126,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/kimberly/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 127,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/kyle/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 128,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/kylie/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 129,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/landon/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 130,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/lauren/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 131,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/leah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 132,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/lillian/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 133,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/lily/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 134,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/logan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 135,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/lucas/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 136,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/luis/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 137,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/luke/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 138,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/mackenzie/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 139,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/madeline/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 140,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/madison/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 141,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/makayla/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 142,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/maria/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 143,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/mariah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 144,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/marissa/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 145,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/mary/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 146,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/mason/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 147,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/matthew/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 148,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/maya/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 149,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/megan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 150,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/melanie/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 151,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/mia/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 152,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/michael/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 153,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/michelle/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 154,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/miguel/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 155,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/morgan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 156,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/natalie/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 157,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/nathan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 158,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/nathaniel/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 159,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/nevaeh/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 160,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/nicholas/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 161,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/nicole/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 162,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/noah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 163,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/olivia/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 164,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/owen/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 165,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/paige/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 166,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/patrick/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 167,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/rachel/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 168,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/rebecca/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 169,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/richard/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 170,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/riley/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 171,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/robert/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 172,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/ryan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 173,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/samantha/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 174,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/samuel/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 175,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/sara/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 176,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/sarah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 177,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/savannah/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 178,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/sean/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 179,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/sebastian/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 180,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/seth/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 181,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/sierra/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 182,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/sofia/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 183,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/sophia/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 184,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/stephanie/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 185,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/steven/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 186,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/sydney/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 187,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/taylor/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 188,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/thomas/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 189,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/timothy/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 190,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/trinity/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 191,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/tristan/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 192,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/tyler/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 193,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/vanessa/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 194,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/victoria/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 195,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/william/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 196,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/wyatt/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 197,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/xavier/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 198,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/zachary/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 199,
-            "type": "add-peer",
-            "configuration": {
-                "address": "mitosis/v1/zoe/webrtc",
-                "signal": "mitosis/v1/signal/wss"
-            }
-        },
-        {
-            "tick": 200,
-            "type": "set-clock-speed",
-            "configuration": {
-                "speed": 100
-            }
-        }
-    ]
+  "instructions": [
+    {
+      "tick": 0,
+      "type": "set-clock-speed",
+      "configuration": {
+        "speed": 250
+      }
+    },
+    {
+      "tick": 0,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/signal/wss",
+        "roles": [
+          "signal"
+        ]
+      }
+    },
+    {
+      "tick": 1,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/aaron/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 2,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/abigail/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 3,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/adam/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 4,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/addison/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 5,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/adrian/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 6,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/aidan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 7,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/aiden/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 8,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/alejandro/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 9,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/alex/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 10,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/alexa/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 11,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/alexander/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 12,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/alexandra/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 13,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/alexis/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 14,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/allison/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 15,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/alyssa/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 16,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/amanda/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 17,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/amber/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 18,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/andrea/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 19,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/andrew/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 20,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/angel/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 21,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/angelina/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 22,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/anna/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 23,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/anthony/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 24,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/antonio/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 25,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/ariana/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 26,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/arianna/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 27,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/ashley/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 28,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/audrey/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 29,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/austin/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 30,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/autumn/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 31,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/ava/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 32,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/avery/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 33,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/bailey/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 34,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/benjamin/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 35,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/blake/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 36,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/brandon/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 37,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/brayden/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 38,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/brian/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 39,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/brianna/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 40,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/brooke/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 41,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/brooklyn/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 42,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/bryan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 43,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/caleb/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 44,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/cameron/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 45,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/carlos/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 46,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/caroline/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 47,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/carson/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 48,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/carter/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 49,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/charles/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 50,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/chase/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 51,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/chloe/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 52,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/christian/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 53,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/christopher/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 54,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/claire/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 55,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/cody/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 56,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/cole/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 57,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/connor/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 58,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/daniel/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 59,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/danielle/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 60,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/david/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 61,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/destiny/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 62,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/devin/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 63,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/diego/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 64,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/dominic/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 65,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/dylan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 66,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/elijah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 67,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/elizabeth/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 68,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/ella/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 69,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/emily/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 70,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/emma/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 71,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/eric/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 72,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/erin/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 73,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/ethan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 74,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/evan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 75,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/evelyn/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 76,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/faith/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 77,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/gabriel/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 78,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/gabriella/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 79,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/gabrielle/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 80,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/gavin/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 81,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/grace/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 82,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/hailey/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 83,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/haley/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 84,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/hannah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 85,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/hayden/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 86,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/hunter/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 87,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/ian/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 88,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/isaac/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 89,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/isabel/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 90,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/isabella/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 91,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/isaiah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 92,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jack/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 93,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jackson/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 94,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jacob/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 95,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jacqueline/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 96,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jada/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 97,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jaden/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 98,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/james/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 99,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jasmine/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 100,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jason/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 101,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jayden/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 102,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jenna/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 103,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jennifer/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 104,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jeremiah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 105,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jesse/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 106,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jessica/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 107,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jesus/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 108,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jocelyn/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 109,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/john/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 110,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jonathan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 111,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jordan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 112,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jordan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 113,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/jose/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 114,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/joseph/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 115,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/joshua/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 116,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/juan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 117,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/julia/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 118,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/julian/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 119,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/justin/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 120,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/kaitlyn/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 121,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/katelyn/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 122,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/katherine/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 123,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/kayla/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 124,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/kaylee/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 125,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/kevin/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 126,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/kimberly/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 127,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/kyle/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 128,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/kylie/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 129,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/landon/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 130,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/lauren/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 131,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/leah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 132,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/lillian/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 133,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/lily/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 134,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/logan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 135,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/lucas/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 136,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/luis/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 137,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/luke/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 138,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/mackenzie/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 139,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/madeline/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 140,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/madison/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 141,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/makayla/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 142,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/maria/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 143,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/mariah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 144,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/marissa/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 145,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/mary/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 146,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/mason/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 147,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/matthew/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 148,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/maya/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 149,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/megan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 150,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/melanie/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 151,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/mia/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 152,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/michael/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 153,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/michelle/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 154,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/miguel/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 155,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/morgan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 156,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/natalie/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 157,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/nathan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 158,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/nathaniel/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 159,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/nevaeh/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 160,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/nicholas/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 161,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/nicole/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 162,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/noah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 163,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/olivia/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 164,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/owen/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 165,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/paige/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 166,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/patrick/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 167,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/rachel/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 168,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/rebecca/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 169,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/richard/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 170,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/riley/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 171,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/robert/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 172,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/ryan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 173,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/samantha/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 174,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/samuel/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 175,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/sara/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 176,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/sarah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 177,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/savannah/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 178,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/sean/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 179,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/sebastian/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 180,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/seth/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 181,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/sierra/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 182,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/sofia/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 183,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/sophia/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 184,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/stephanie/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 185,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/steven/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 186,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/sydney/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 187,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/taylor/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 188,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/thomas/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 189,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/timothy/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 190,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/trinity/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 191,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/tristan/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 192,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/tyler/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 193,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/vanessa/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 194,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/victoria/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 195,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/william/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 196,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/wyatt/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 197,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/xavier/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 198,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/zachary/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 199,
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/zoe/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 200,
+      "type": "set-clock-speed",
+      "configuration": {
+        "speed": 100
+      }
+    },
+    {
+      "tick": 620,
+      "type": "finish-scenario"
+    }
+  ]
 }

--- a/visualization/src/scenarios/triangle.json
+++ b/visualization/src/scenarios/triangle.json
@@ -2,6 +2,13 @@
   "instructions": [
     {
       "tick": 0,
+      "type": "set-clock-speed",
+      "configuration": {
+        "speed": 50
+      }
+    },
+    {
+      "tick": 0,
       "type": "add-peer",
       "configuration": {
         "address": "mitosis/v1/signal/wss",
@@ -28,7 +35,22 @@
     },
     {
       "tick": 0,
-      "type": "pause-clock"
+      "type": "add-peer",
+      "configuration": {
+        "address": "mitosis/v1/claire/webrtc",
+        "signal": "mitosis/v1/signal/wss"
+      }
+    },
+    {
+      "tick": 24,
+      "type": "set-clock-speed",
+      "configuration": {
+        "speed": 250
+      }
+    },
+    {
+      "tick": 25,
+      "type": "finish-scenario"
     }
   ]
 }


### PR DESCRIPTION
- Add new protocol `via-multi` for all peers that not have been added by a peer-update message
- Answer with `unknow-peer` message when message can not be forwarded
- Remove via connections to a peer on `unknown-peer` message
- When removing a peer from `peer-manager` send a `unknown-peer` message to all direct peers
- Update `last-seen` of via peers on message receive
- Highlight expired peers in visualisation (expired peers are not removed yet )